### PR TITLE
fix: remove duplicated wording in test run

### DIFF
--- a/resource/example_test_run.json
+++ b/resource/example_test_run.json
@@ -466,9 +466,9 @@
         "ancestorTitles": [
             "🗃️  S11 ETH Failures in past 2.00 hours should be reported correctly"
         ],
-        "fullName": "🗃️  S11 ETH Failures in past 2.00 hours should be reported correctly 📁  S11C200 should have have ExtrinsicSuccess for all ethereum.transact",
+        "fullName": "🗃️  S11 ETH Failures in past 2.00 hours should be reported correctly 📁  S11C200 should have ExtrinsicSuccess for all ethereum.transact",
         "status": "skipped",
-        "title": "📁  S11C200 should have have ExtrinsicSuccess for all ethereum.transact",
+        "title": "📁  S11C200 should have ExtrinsicSuccess for all ethereum.transact",
         "failureMessages": [],
         "location": {
             "line": 132,


### PR DESCRIPTION
## Summary
- fix duplicated "have" wording for S11C200 entries in example test run JSON

## Testing
- `bun test` *(fails: Failed to connect)*
- `jq empty resource/example_test_run.json` *(fails: Unmatched ']' at line 74)*

------
https://chatgpt.com/codex/tasks/task_e_689352333c8c8331b36ba62b44b45f76